### PR TITLE
Adding `task` param to `torchmetrics.Accuracy` and `torchmetrics.AveragePrecision`

### DIFF
--- a/clmr/modules/linear_evaluation.py
+++ b/clmr/modules/linear_evaluation.py
@@ -28,8 +28,15 @@ class LinearEvaluation(LightningModule):
             self.model = nn.Sequential(nn.Linear(self.hidden_dim, self.output_dim))
         self.criterion = self.configure_criterion()
 
-        self.accuracy = torchmetrics.Accuracy()
-        self.average_precision = torchmetrics.AveragePrecision(pos_label=1)
+        self.accuracy = torchmetrics.Accuracy(
+            task="multilabel",
+            num_labels=output_dim
+        )
+        self.average_precision = torchmetrics.AveragePrecision(
+            task='multilabel',
+            num_labels=output_dim,
+            pos_label=1
+        )
 
     def forward(self, x: Tensor, y: Tensor) -> Tuple[Tensor, Tensor]:
         preds = self._forward_representations(x, y)


### PR DESCRIPTION
This is within `clmr.modules.linear_evaluation.LinearEvaluation`

Addresses #24 